### PR TITLE
✨ feat: use .gitignore to exclude unwanted pubspecs

### DIFF
--- a/lib/src/command/analyze.dart
+++ b/lib/src/command/analyze.dart
@@ -1,11 +1,9 @@
 import 'package:args/command_runner.dart';
-import 'package:glob/glob.dart';
-import 'package:glob/list_local_fs.dart';
 import 'package:mason_logger/mason_logger.dart';
-import 'package:path/path.dart';
 import 'package:pmv/src/entities/dependency.dart';
 import 'package:pmv/src/extensions/dependency.dart';
 import 'package:pmv/src/file.dart';
+import 'package:pmv/src/utils/pubspec_finder.dart';
 import 'package:pubspec/pubspec.dart';
 
 class AnalyzeSubPackageCommand extends Command<int> {
@@ -49,14 +47,14 @@ class AnalyzeSubPackageCommand extends Command<int> {
     Map<String, Dependency> allDevDependencies = {};
     Map<String, Dependency> allOverrideDependencies = {};
 
-    final progress = _logger.progress('Analyze sub project pubspec in progress');
+    final progress =
+        _logger.progress('Analyze sub project pubspec in progress');
 
     try {
       // analyze dependencies
-      final pubspecFiles = Glob(join('.', '**', 'pubspec.yaml'));
-      for (final entity in pubspecFiles.listSync()) {
-        final pubSpec = await PubSpec.loadFile(entity.path);
-        final projectName = pubSpec.name ?? 'unknow';
+      final pubspecFiles = await PubspecFinder.findAll();
+      for (final (pubSpec, _) in pubspecFiles) {
+        final projectName = pubSpec.name ?? 'unknown';
 
         allDependencies = _analyzePubFile(
           projectName: projectName,

--- a/lib/src/command/apply.dart
+++ b/lib/src/command/apply.dart
@@ -1,8 +1,6 @@
 import 'package:args/command_runner.dart';
-import 'package:glob/glob.dart';
-import 'package:glob/list_local_fs.dart';
 import 'package:mason_logger/mason_logger.dart';
-import 'package:path/path.dart';
+import 'package:pmv/src/utils/pubspec_finder.dart';
 import 'package:pubspec/pubspec.dart';
 
 class ApplySubPackageCommand extends Command<int> {
@@ -10,7 +8,8 @@ class ApplySubPackageCommand extends Command<int> {
     argParser.addOption(
       'source',
       abbr: 's',
-      help: 'The path of the reference pubspec file (pmv_pubspec.yaml by default).',
+      help:
+          'The path of the reference pubspec file (pmv_pubspec.yaml by default).',
       defaultsTo: './pmv_pubspec.yaml',
     );
   }
@@ -29,7 +28,8 @@ class ApplySubPackageCommand extends Command<int> {
 
   @override
   Future<int> run() async {
-    final progress = _logger.progress("Apply reference pubspec version in progress");
+    final progress =
+        _logger.progress("Apply reference pubspec version in progress");
     final rootFile = argResults?['source'] as String;
     int countFile = 0;
 
@@ -37,9 +37,8 @@ class ApplySubPackageCommand extends Command<int> {
     final rootPubSpec = await PubSpec.loadFile(rootFile);
 
     //Apply version to sub pubspec
-    final pubspecFiles = Glob(join('.', '**', 'pubspec.yaml'));
-    for (final entity in pubspecFiles.listSync()) {
-      final pubSpec = await PubSpec.loadFile(entity.path);
+    final pubspecFiles = await PubspecFinder.findAll();
+    for (final (pubSpec, path) in pubspecFiles) {
       bool updateNeed = false;
 
       rootPubSpec.dependencies.forEach((key, rootDep) {
@@ -78,7 +77,7 @@ class ApplySubPackageCommand extends Command<int> {
       //Update yaml file
       if (updateNeed) {
         _logger.detail("${pubSpec.name} save");
-        pubSpec.save(entity.parent);
+        pubSpec.save(path);
         countFile++;
       }
     }

--- a/lib/src/utils/pubspec_finder.dart
+++ b/lib/src/utils/pubspec_finder.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
+import 'package:path/path.dart';
+import 'package:pubspec/pubspec.dart';
+
+final _pubSpecGlob = Glob(join('.', '**', 'pubspec.yaml'));
+
+class PubspecFinder {
+  static Future<List<(PubSpec, Directory path)>> findAll(
+      {List<String> ignorePaths = const ['.gitignore']}) async {
+    final ignoreGlobs = <Glob>{};
+    for (final ignorePath in ignorePaths) {
+      final ignoreFile = File(ignorePath);
+      for (final line in await ignoreFile.readAsLines()) {
+        if (!line.startsWith('#') && line.isNotEmpty) {
+          ignoreGlobs.add(
+            Glob(
+              line.replaceAll(RegExp(r'/$'), ''),
+              recursive: true,
+            ),
+          );
+        }
+      }
+    }
+
+    final asyncPubSpecs = <Future<(PubSpec, Directory)>>[];
+    for (final pubspec in _pubSpecGlob.listSync()) {
+      final path = pubspec.path.replaceAll(RegExp(r'^(\./)*'), '');
+
+      if (!ignoreGlobs.any((glob) => glob.matches(path))) {
+        asyncPubSpecs.add(Future(
+          () async => (await PubSpec.loadFile(path), pubspec.parent),
+        ));
+      }
+    }
+
+    return Future.wait(asyncPubSpecs);
+  }
+}


### PR DESCRIPTION
When using PMV with FVM, the tool overrides versions inside of flutter sdk which is not a good behavior.

To remedy this issue, I propose to take the gitignore file into account. This would permit to only update project's pubspecs.